### PR TITLE
Fix for issue with ID #22586 :- Show action logs for guest users as w…

### DIFF
--- a/administrator/components/com_actionlogs/models/actionlogs.php
+++ b/administrator/components/com_actionlogs/models/actionlogs.php
@@ -86,7 +86,7 @@ class ActionlogsModelActionlogs extends JModelList
 		$query = $db->getQuery(true)
 			->select('a.*, u.name')
 			->from('#__action_logs AS a')
-			->innerJoin('#__users AS u ON a.user_id = u.id');
+			->leftJoin('#__users AS u ON a.user_id = u.id');
 
 		// Get ordering
 		$fullorderCol = $this->state->get('list.fullordering', 'a.id DESC');


### PR DESCRIPTION
…ell as registered users

Pull Request for Issue #22586 .

### Summary of Changes
Change the Join type from "inner" to "left" so that the logs of guest users are also shown in the "User Action Logs" view in the backend  


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

